### PR TITLE
feat: implemented continuous delivery with version support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Add permission to push back to the repository
+    permissions:
+      contents: write
+      packages: write
+
     strategy:
       matrix:
         node-version: [22.x]
@@ -15,14 +20,27 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           registry-url: "https://registry.npmjs.org"
 
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
       - name: Install dependencies
         run: npm install
+
+      - name: Bump version
+        run: |
+          npm version patch -m "chore: bump version to %s [skip ci]"
+          git push
+          git push --tags
 
       - name: Build the project
         run: npm run build


### PR DESCRIPTION
When we will merge PR to the main branch, publish Git-Action will be triggered and new version will be patched to the npm library. Simple continuous delivery

### Tested Locally
Current version: **v1.0.20**
```
npm version patch
v1.0.21
```
```
git log -1 --pretty=%B | cat && echo "\nTag:" && git describe --tags --abbrev=0
1.0.21
```
```
grep '"version":' package.json
"version": "1.0.21",
```